### PR TITLE
trim email address on inputs

### DIFF
--- a/classes/models/class.admin.php
+++ b/classes/models/class.admin.php
@@ -29,6 +29,10 @@ class MW_WP_Form_Admin {
 			return $post_id;
 
 		$data = $_POST[MWF_Config::NAME];
+		$triminglists = array("mail_from","mail_to","admin_mail_from");
+		foreach ($triminglists as $name) {
+			$data[$name] = trim(mb_convert_kana($data[$name], "s", 'UTF-8'));
+		}
 		if ( !empty( $data['validation'] ) && is_array( $data['validation'] ) ) {
 			$validation = array();
 			foreach ( $data['validation'] as $_validation ) {


### PR DESCRIPTION
いつも使わせて頂いてます。

フォーム設定ページの返信メールの送信先やFromに表示するアドレスの欄など、
半角スペースおよび全角スペースが入力されてもエラーがでなかったので、
保存時に前後の半角スペースと全角スペースをトリムするようにしました。
送信時にはtrim処理がはいっていましたが、入力欄で反映されていると安心するかなと思いました。
該当項目
"mail_from"
"mail_to"
"admin_mail_from"

--
Trim full width/half width of email inputbox on setting page when save it. 
