### PR TITLE
filter hook 'mwform_value_#{form_key}' does not work when to use radio or checkboxes

### DIFF
--- a/classes/models/class.abstract-form-field.php
+++ b/classes/models/class.abstract-form-field.php
@@ -160,7 +160,7 @@ abstract class MW_WP_Form_Abstract_Form_Field {
 	 */
 	abstract protected function input_page();
 	public function _input_page( $atts ) {
-		if ( isset( $this->defaults['value'], $atts['name'] ) && !isset( $atts['value'] ) ) {
+		if ( array_key_exists( 'value', $this->defaults ) && isset( $atts['name'] ) && !isset( $atts['value'] ) ) {
 			$atts['value'] = apply_filters(
 				'mwform_value_' . $this->form_key,
 				$this->defaults['value'],


### PR DESCRIPTION
mw-wp-form活用させていただいています。

フォームの初期値をフックを使って動的に書き換えていたのですが、ラジオボタンとチェックボックス使用時にフックされない現象が起こりました。
$this->defaults['value']にnullが入っているとフック処理に辿りつけないようなので、判定を少し変えてみました。