### PR TITLE
Add filter hook mwform_content_wpautop, mwform_complete_wpautop.

### DIFF
--- a/classes/services/class.exec-shortcode.php
+++ b/classes/services/class.exec-shortcode.php
@@ -318,7 +318,16 @@ class MW_WP_Form_Exec_Shortcode {
 		$post     = get_post( $post_id );
 		setup_postdata( $post );
 		$content = apply_filters( 'mwform_post_content_raw_' . $form_key, get_the_content() );
+		//wpautopが有効かどうかの判定を変数に格納
 		if ( has_filter( 'the_content', 'wpautop' ) ) {
+			$has_wpautop = (bool)'true';
+		} else {
+			$has_wpautop = (bool)'';
+		}
+		//wpautopを無効にできるようにフックを追加
+		$has_wpautop = apply_filters( 'mwform_content_wpautop', $has_wpautop );
+		//$has_wpautopがtrueの時のみwpautopを適用
+		if ( $has_wpautop ) {
 			$content = wpautop( $content );
 		}
 		$content = sprintf(
@@ -347,7 +356,16 @@ class MW_WP_Form_Exec_Shortcode {
 	protected function get_complete_page_content() {
 		$Setting = $this->Setting;
 		$content = $Setting->get( 'complete_message' );
+		//wpautopが有効かどうかの判定を変数に格納
 		if ( has_filter( 'the_content', 'wpautop' ) ) {
+			$has_wpautop = (bool)'true';
+		} else {
+			$has_wpautop = (bool)'';
+		}
+		//wpautopを無効にできるようにフックを追加
+		$has_wpautop = apply_filters( 'mwform_complete_wpautop', $has_wpautop );
+		//$has_wpautopがtrueの時のみwpautopを適用
+		if ( $has_wpautop ) {
 			$content = wpautop( $content );
 		}
 		$content = sprintf(

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ Source: https://developers.google.com/chart/
 * [Kazuto Takeshita](http://mt8.biz/) ( [moto hachi](https://profiles.wordpress.org/mt8biz/) )
 * [Atsushi Ando](http://www.next-season.net/) ( [NExt-Season](https://profiles.wordpress.org/next-season/) )
 * [Kazuki Tomiyasu](http://visualive.jp/) ( [KUCKLU](https://profiles.wordpress.org/kuck1u/) )
-* [Key Nomura](http://mypacecreator.net/) ( [mypacecreator](https://profiles.wordpress.org/mypacecreator/) )
+* [Kei Nomura](http://mypacecreator.net/) ( [mypacecreator](https://profiles.wordpress.org/mypacecreator/) )
 * [mh35](https://profiles.wordpress.org/mh35)
 
 == Installation ==


### PR DESCRIPTION
処理のタイミング的に、フォームの作成フィールドで`remove_filter('the_content', 'wpautop');`ができないので、なんとかして外側からwpautopの処理を外せないものかと考えた結果、こんな感じになりました。

ユーザー側ではシンプルに
`add_filter( 'mwform_content_wpautop', '__return_false' ); `
`add_filter( 'mwform_complete_wpautop', '__return_false' ); `
をすればよいようにしました。

ほかにスマートなやり方が思いつかなかったのですが...いかがなもんでしょうか...（汗