### PR TITLE
#42 メールのPostIDを取得するための修正

### DIFF
--- a/classes/models/class.mail.php
+++ b/classes/models/class.mail.php
@@ -61,6 +61,11 @@ class MW_WP_Form_Mail {
 	public $attachments = array();
 
 	/**
+	 * @var MW_WP_Form_Mail_Parser
+	 */
+	protected $Mail_Parser;
+
+	/**
 	 * メール送信
 	 */
 	public function send() {
@@ -340,5 +345,14 @@ class MW_WP_Form_Mail {
 		foreach ( get_object_vars( $Mail ) as $key => $value ) {
 			$this->$key = $value;
 		}
+	}
+
+	/**
+	 * 保存した問い合わせデータの Post IDを取得する
+	 *
+	 * @return int
+	 */
+	public function get_saved_id(){
+		return $this->Mail_Parser->get_insert_contact_data_id();
 	}
 }

--- a/classes/services/class.mail-parser.php
+++ b/classes/services/class.mail-parser.php
@@ -74,6 +74,15 @@ class MW_WP_Form_Mail_Parser {
 	}
 
 	/**
+	 * Getter : $this->insert_contact_data_id
+	 *
+	 * @return int
+	 */
+	public function get_insert_contact_data_id(){
+		return $this->insert_contact_data_id;
+	}
+
+	/**
 	 * メールオブジェクトの各プロパティを変換
 	 *
 	 * @param bool $do_update


### PR DESCRIPTION
Issueにあげた件、作ってみました。
モデルに$Mail_Parserを含めてよいかわからなかったのですが、最低限の情報のみ（Post IDのみ）返すようにしています。

このサンプルコードで取得できるようになってます。

```
function sample($mail, $data) {
    $mailid = $mail->get_saved_id(); // DBに保存されたIDを取得
    $savedmail = get_post($mailid); // メールのPOSTを取得

}
add_action( 'mwform_before_send_admin_mail_mw-wp-form-6', 'sample', 10, 2  );
```