### PR TITLE
[mwform_formkey] support 'slug' attribute

### DIFF
--- a/classes/services/class.exec-shortcode.php
+++ b/classes/services/class.exec-shortcode.php
@@ -207,7 +207,25 @@ class MW_WP_Form_Exec_Shortcode {
 		$attributes = shortcode_atts( array(
 			'key' => '',
 		), $attributes );
-		$post = get_post( $attributes['key'] );
+		$post = null;
+
+		if ( !empty( $attributes['slug'] ) ) {
+			// スラッグより取得
+			$args = array(
+				'name'        => $attributes['slug'],
+				'post_type'   => MWF_Config::NAME,
+				'numberposts' => 1,
+			);
+			$posts = get_posts( $args );
+			if ( !empty( $posts ) ) {
+				$post = $posts[0];
+			}
+		}
+
+		if ( empty( $post ) ) {
+			$post = get_post( $attributes['key'] );
+		}
+
 		if ( isset( $post->ID ) ) {
 			return $post->ID;
 		}

--- a/classes/services/class.exec-shortcode.php
+++ b/classes/services/class.exec-shortcode.php
@@ -205,7 +205,8 @@ class MW_WP_Form_Exec_Shortcode {
 	 */
 	protected function get_form_id_by_mwform_formkey( $attributes ) {
 		$attributes = shortcode_atts( array(
-			'key' => '',
+			'key'  => '',
+			'slug' => '',
 		), $attributes );
 		$post = null;
 


### PR DESCRIPTION
keyでフォームを指定して読み込む場合、開発環境と本番環境でpost IDが異なる場合があり、テンプレートにショートコードを埋め込む場合、書き換えが必要になります。

そこで、[mwform_formkey slug="form_slug"] のようにslugでのフォーム指定を可能にします。