### PR TITLE
CSVダウンロード時のメモリ使用量を削減

### DIFF
--- a/classes/models/class.csv.php
+++ b/classes/models/class.csv.php
@@ -33,44 +33,63 @@ class MW_WP_Form_CSV {
 			return;
 		}
 
+		// max_execution_time の制約を回避
+		set_time_limit( 0 );
+
+		// ダウンロード条件を取得
+		$args           = $this->get_query_args();
 		$posts_per_page = $this->get_posts_per_page();
-		$paged          = $this->get_paged();
+		$download_all   = isset( $_POST['download-all'] ) && $_POST['download-all'] === 'true';
 
-		$_args = apply_filters( 'mwform_get_inquiry_data_args-' . $this->post_type, array() );
-		$args  = array(
-			'post_type'      => $this->post_type,
-			'posts_per_page' => $posts_per_page,
-			'paged'          => $paged,
-			'post_status'    => 'any',
-		);
-		if ( !empty( $_args ) && is_array( $_args ) ) {
-			$args = array_merge( $_args, $args );
+		// 全件ダウンロードする場合は全ページを列挙、しない場合は指定されたページのみ列挙
+		if ( $download_all ) {
+			$first_page = 1;
+			$last_page  = ceil( $this->get_count( $args ) / $posts_per_page );
+		} else {
+			$first_page = $this->get_paged();
+			$last_page  = $first_page;
 		}
-		$posts_mwf = get_posts( $args );
 
-		// CSVの内容を貯める
-		$csv = '';
-
-		// 見出しを追加
-		$rows[0] = $this->get_csv_headings( $posts_mwf );
-
-		// 各データを追加
-		$rows = array_merge( $rows, $this->get_rows( $posts_mwf, $rows[0] ) );
-
-		// エンコード
-		foreach ( $rows as $key => $row ) {
-			foreach ( $row as $column_name => $column ) {
-				$row[$column_name] = $this->escape_double_quote( $column );
-			}
-			$csv .= implode( ',', $row ) . "\r\n";
-		}
-		$to_encoding = apply_filters( 'mwform_csv_encoding-' . $this->post_type, 'sjis-win' );
-		$csv = mb_convert_encoding( $csv, $to_encoding, get_option( 'blog_charset' ) );
-
+		// レスポンスヘッダーを出力
 		$file_name = 'mw_wp_form_' . date( 'YmdHis' ) . '.csv';
 		header( 'Content-Type: application/octet-stream' );
 		header( 'Content-Disposition: attachment; filename=' . $file_name );
-		echo $csv;
+
+		// 出力範囲の問い合わせデータを基に見出しを作成
+		$header = $this->get_csv_headings( $args, $first_page, $last_page );
+
+		// 分割エンコード＆出力
+		for ( $paged = $first_page; $paged <= $last_page; $paged ++ ) {
+			$args['paged'] = $paged;
+			$posts_mwf     = get_posts( $args );
+
+			// CSVの内容を貯める
+			$rows = array();
+			$csv  = '';
+
+			// 見出しを追加
+			if ( $paged == $first_page ) {
+				$rows[] = $header;
+			}
+
+			// 各データを追加
+			$rows = array_merge( $rows, $this->get_rows( $posts_mwf, $header ) );
+
+			// エンコード
+			foreach ( $rows as $key => $row ) {
+				foreach ( $row as $column_name => $column ) {
+					$row[ $column_name ] = $this->escape_double_quote( $column );
+				}
+				$csv .= implode( ',', $row ) . "\r\n";
+			}
+			$to_encoding = apply_filters( 'mwform_csv_encoding-' . $this->post_type, 'sjis-win' );
+			$csv         = mb_convert_encoding( $csv, $to_encoding, get_option( 'blog_charset' ) );
+			echo $csv;
+
+			// キャッシュされた投稿データと投稿メタデータを開放
+			wp_cache_flush();
+		}
+
 		exit;
 	}
 
@@ -80,15 +99,12 @@ class MW_WP_Form_CSV {
 	 * @return int
 	 */
 	public function get_posts_per_page() {
-		$posts_per_page = -1;
-		if ( ( isset( $_POST['download-all'] ) && $_POST['download-all'] === 'true' ) === false ) {
-			$current_user = wp_get_current_user();
-			$_posts_per_page = get_user_meta( $current_user->ID, 'edit_' . $this->post_type . '_per_page', true );
-			if ( !empty( $_posts_per_page ) ) {
-				$posts_per_page = $_posts_per_page;
-			} else {
-				$posts_per_page = 20;
-			}
+		$current_user    = wp_get_current_user();
+		$_posts_per_page = get_user_meta( $current_user->ID, 'edit_' . $this->post_type . '_per_page', true );
+		if ( !empty( $_posts_per_page ) ) {
+			$posts_per_page = $_posts_per_page;
+		} else {
+			$posts_per_page = 20;
 		}
 		return $posts_per_page;
 	}
@@ -99,11 +115,10 @@ class MW_WP_Form_CSV {
 	 * @return int
 	 */
 	public function get_paged() {
-		$posts_per_page = $this->get_posts_per_page();
 		$paged = 1;
 		if ( isset( $_GET['paged'] ) ) {
 			$_paged = $_GET['paged'];
-			if ( MWF_Functions::is_numeric( $_paged ) && $posts_per_page > 0 ) {
+			if ( MWF_Functions::is_numeric( $_paged ) ) {
 				$paged = $_paged;
 			}
 		}
@@ -111,12 +126,45 @@ class MW_WP_Form_CSV {
 	}
 
 	/**
-	 * CSVの見出しを生成
+	 * データ件数を取得
 	 *
-	 * @param array $posts
+	 * @param array $args
+	 * @return int 投稿数
+	 */
+	public function get_count( array $args ) {
+		$args['posts_per_page'] = 1;
+		$query                  = new WP_Query( $args );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * 問い合わせデータ取得クエリ用の引数を生成
+	 *
 	 * @return array
 	 */
-	protected function get_csv_headings( array $posts ) {
+	public function get_query_args() {
+		$_args = apply_filters( 'mwform_get_inquiry_data_args-' . $this->post_type, array() );
+		$args  = array(
+			'post_type'   => $this->post_type,
+			'post_status' => 'any',
+		);
+		if ( !empty( $_args ) && is_array( $_args ) ) {
+			$args = array_merge( $_args, $args );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * CSVの見出しを生成
+	 *
+	 * @param array $args
+	 * @param int   $first_page
+	 * @param int   $last_page
+	 * @return array
+	 */
+	protected function get_csv_headings( array $args, $first_page, $last_page ) {
 		$columns = array(
 			'ID'              => 'ID',
 			'response_status' => __( 'Response Status', 'mw-wp-form' ),
@@ -125,22 +173,32 @@ class MW_WP_Form_CSV {
 			'post_title'      => 'post_title',
 		);
 		$_columns = array();
-		foreach ( $posts as $post ) {
-			$post_custom_keys = get_post_custom_keys( $post->ID );
-			if ( !is_array( $post_custom_keys ) ) {
-				continue;
-			}
-			foreach ( $post_custom_keys as $key ) {
-				if ( preg_match( '/^_/', $key ) ) {
+
+		for ( $paged = $first_page; $paged <= $last_page; $paged ++ ) {
+			$args['paged'] = $paged;
+			$posts         = get_posts( $args );
+
+			foreach ( $posts as $post ) {
+				$post_custom_keys = get_post_custom_keys( $post->ID );
+				if ( !is_array( $post_custom_keys ) ) {
 					continue;
 				}
-				if ( $key === MWF_Config::TRACKINGNUMBER ) {
-					$columns[$key] = MWF_Functions::get_tracking_number_title( $this->post_type );
-					continue;
+				foreach ( $post_custom_keys as $key ) {
+					if ( preg_match( '/^_/', $key ) ) {
+						continue;
+					}
+					if ( $key === MWF_Config::TRACKINGNUMBER ) {
+						$columns[$key] = MWF_Functions::get_tracking_number_title( $this->post_type );
+						continue;
+					}
+					$_columns[$key] = $key;
 				}
-				$_columns[$key] = $key;
 			}
+
+			// キャッシュされた投稿データと投稿メタデータを開放
+			wp_cache_flush();
 		}
+
 		ksort( $_columns );
 		$_columns = apply_filters( 'mwform_inquiry_data_columns-' . $this->post_type, $_columns );
 		$columns = array_merge( $columns, $_columns );

--- a/tests/test-mw-wp-form-csv.php
+++ b/tests/test-mw-wp-form-csv.php
@@ -55,7 +55,7 @@ class MW_WP_Form_CSV_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_posts_per_page_Allあり_表示件数設定なし() {
 		$_POST['download-all'] = 'true';
-		$this->assertEquals( -1, $this->CSV->get_posts_per_page() );
+		$this->assertEquals( 20, $this->CSV->get_posts_per_page() );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class MW_WP_Form_CSV_Test extends WP_UnitTestCase {
 		$_POST['download-all'] = 'true';
 		$user_id = $this->set_current_user();
 		update_user_meta( $user_id, 'edit_' . $this->post_type . '_per_page', 10 );
-		$this->assertEquals( -1, $this->CSV->get_posts_per_page() );
+		$this->assertEquals( 10, $this->CSV->get_posts_per_page() );
 	}
 
 	/**
@@ -84,12 +84,26 @@ class MW_WP_Form_CSV_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @group get_paged
+	 * @group get_query_args
 	 */
-	public function test_get_paged_全件表示のときは1() {
-		$_GET['paged'] = 2;
-		$_POST['download-all'] = 'true';
-		$this->assertEquals( 1, $this->CSV->get_paged() );
+	public function test_get_query_args() {
+		$expected = array(
+			'post_type'   => $this->post_type,
+			'post_status' => 'any',
+		);
+
+		$actual = $this->CSV->get_query_args();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @group get_count
+	 * @depends test_get_query_args
+	 */
+	public function test_get_count() {
+		$args = $this->CSV->get_query_args();
+		$this->assertEquals( 50, $this->CSV->get_count( $args ) );
 	}
 
 	/**


### PR DESCRIPTION
#51  に関するPRです。
`[Download All]` チェック時のCSVダウンロード処理に対して、
使用メモリを減らすように変更しています。

* `get_posts()` によるデータの一括取得を、分割して取得するように変更。
* `MW_WP_Form_Chart_Controller::get_paged()` は常に設定値またはデフォルト値を返すように変更。
* `max_execution_time` 対策を追加。

分割時の取得件数は、1ページの表示件数を引き継いで使用するようにしています。
別途設定を設けた方がベストだと思いますが、手抜きしちゃいました＞＜

CSVのヘッダー出力の仕様ですが、
出力範囲内の問い合わせデータに基づいて、カラムを取得するように変更しました。
また1ページ目のみの出力、2ページ目のみの出力でカラムが異なる可能性がありますが、
こちらは旧来の挙動を引き継いでおります。

--- 
以下廃案。
~~1ページ目で取得可能なカラムのみを出力し、
2ページ目以降に出現するカラムは名無しのカラムとして扱うよう実装しています。
一度総なめして正確に取得するかどうか悩みました…
とりあえず実行速度を優先にしています。
このあたりよろしければご判断をお願いできましたら幸いです。~~

~~問い合わせデータ~~

| ID | 項目名 | 値 |
| --- | --- | --- |
| 1 | A | 1 |
| 1 | B | 1 |
| 2 | B | 2 |
| 2 | C | 2 |

~~CSV出力結果~~

| ID | A | B |   |
| --- | --- | --- | --- |
| 1 | 1 | 1 | |
| 2 |  | 2 | 2 |
