### PR TITLE
アップロードファイルのサイズのバリデーション判定時にアップロードエラーもチェックする

### DIFF
--- a/classes/validation-rules/class.filesize.php
+++ b/classes/validation-rules/class.filesize.php
@@ -39,6 +39,9 @@ class MW_WP_Form_Validation_Rule_FileSize extends MW_WP_Form_Abstract_Validation
 					return $options['message'];
 				}
 			}
+			elseif ( $file['error'] == 1 ) {
+				return "画像のアップロードに失敗しました。";
+			}
 		}
 	}
 

--- a/classes/validation-rules/class.filesize.php
+++ b/classes/validation-rules/class.filesize.php
@@ -40,7 +40,7 @@ class MW_WP_Form_Validation_Rule_FileSize extends MW_WP_Form_Abstract_Validation
 				}
 			}
 			elseif ( $file['error'] == 1 ) {
-				return "画像のアップロードに失敗しました。";
+				return "Unfortunately, failed to upload the file.";
 			}
 		}
 	}


### PR DESCRIPTION
PHPの制限でアップロードに失敗した場合でも、既存のバリデーションルールだとファイルサイズが0とみなされバリデーションを通過していました。
そこでファイルサイズが0の場合にアップロードエラーチェックをするようにしました。