### PR TITLE
add_filterにフックする関数のアクセス権をpublicに変更

### DIFF
--- a/classes/functions.php
+++ b/classes/functions.php
@@ -148,7 +148,7 @@ class MWF_Functions {
 		unset( $mwform_deprecated_message );
 		echo $content;
 	}
-	protected static function _return_deprecated_message( $content = '' ) {
+	public static function _return_deprecated_message( $content = '' ) {
 		global $mwform_deprecated_message;
 		$content = $mwform_deprecated_message . $content;
 		unset( $mwform_deprecated_message );


### PR DESCRIPTION
`deprecated_message`内`add_filter( 'the_content', 'MWF_Functions::_return_deprecated_message' );`が実行された時に #88 のPHPエラーになるためメソッドのアクセス権を`public`に変更しました。