### PR TITLE
wavのmimetypeとしてaudio/x-wav等を追加

### DIFF
--- a/classes/functions.php
+++ b/classes/functions.php
@@ -303,6 +303,14 @@ class MWF_Functions {
 						'audio/mpeg',
 					);
 					break;
+				case 'wav':
+					$wp_check_filetype['type'] = array(
+						$wp_check_filetype['type'],
+						'audio/wave',
+						'audio/x-wav',
+						'audio/x-pn-wav',
+					);
+					break;
 				case 'mpg':
 					$wp_check_filetype['type'] = array(
 						'audio/mpeg',


### PR DESCRIPTION
手元のwavファイルを送信する際、

- `wp_check_filetype()` で `audio/wav` と判定
- `$finfo->file()` で `audio/x-wav` と判定

されたため、ファイルが添付されずに消えてしまいました。

追加のmimetypeは
https://developer.mozilla.org/ja/docs/Web/HTTP/Basics_of_HTTP/MIME_types
からの引用です。

よろしければマージお願いいたします。