### PR TITLE
Fix infinite redirections with asterisks

### DIFF
--- a/classes/services/class.redirected.php
+++ b/classes/services/class.redirected.php
@@ -171,7 +171,7 @@ class MW_WP_Form_Redirected {
 		}
 
 		if ( ! empty( $query_string ) ) {
-			return $url . '?' . http_build_query( $query_string, null, '&' );
+			return $url . '?' . build_query( $query_string );
 		}
 
 		return $url;

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+  "name": "inc2734/mw-wp-form",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/tests/classes/services/test-redirected.php
+++ b/tests/classes/services/test-redirected.php
@@ -237,6 +237,7 @@ class MW_WP_Form_Redirected_Test extends WP_UnitTestCase {
 		$_GET = array(
 			'foo'     => 'bar',
 			'post_id' => 1,
+			'with_asterisk' => 'foo*bar',
 		);
 
 		$Setting = new MW_WP_Form_Setting( $form_id );
@@ -250,37 +251,37 @@ class MW_WP_Form_Redirected_Test extends WP_UnitTestCase {
 		$is_valid       = false;
 		$post_condition = 'back';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 
 		// Pattern: ! $is_valid, confirm
 		$is_valid       = false;
 		$post_condition = 'confirm';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 
 		// Pattern: ! $is_valid, complete
 		$is_valid       = false;
 		$post_condition = 'complete';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/error/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 
 		// Pattern: $is_valid, back
 		$is_valid       = true;
 		$post_condition = 'back';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 
 		// Pattern: $is_valid, confirm
 		$is_valid       = true;
 		$post_condition = 'confirm';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/confirm/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/confirm/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 
 		// Pattern: $is_valid, complete
 		$is_valid       = true;
 		$post_condition = 'complete';
 		$Redirected = new MW_WP_Form_Redirected( $form_key, $Setting, $is_valid, $post_condition );
-		$this->assertEquals( home_url( '/contact/complete/?foo=bar&post_id=1' ), $Redirected->get_url() );
+		$this->assertEquals( home_url( '/contact/complete/?foo=bar&post_id=1&with_asterisk=foo*bar' ), $Redirected->get_url() );
 	}
 
 	/**


### PR DESCRIPTION
# 概要
#128 に対応しました。

現在こちらのプラグインをあまり[積極的にメンテナンスされているわけではない](https://twitter.com/inc2734/status/1366777238176165888?s=20&t=AEjNAFt_OJB8VToZu9ZIsw)かもしれませんが、一応 PR お送りしますので、お忙しいとは思いますが、よろしければお時間が許すときにでもご査収頂けますと幸いです。

# 変更点
- WordPress の Core が提供する [build_query()](https://developer.wordpress.org/reference/functions/build_query/) に置き換えました。
- `querystring` オプション利用時のテストケースを、アスタリスク対応しているか確認するように調整しました。
- composer.json の `name` フィールドを追加しました。
  - こちらのプラグインを利用している WP 環境で、 composer.json のリポジトリ指定にて、パッチ当てたものをインストールする上で必要だったため追加させて頂きました。