### PR TITLE
Batcacheによるキャッシュの回避

### DIFF
--- a/classes/controllers/class.main.php
+++ b/classes/controllers/class.main.php
@@ -85,7 +85,7 @@ class MW_WP_Form_Main_Controller {
 	 */
 	public function _nocache_headers( $headers ) {
 		$headers['X-Accel-Expires'] = 0;
-		$headers['Cache-Control']   = 'private, no-store, no-cache, must-revalidate';
+		$headers['Cache-Control']   = 'private, no-store, no-cache, must-revalidate, max-age=0';
 		return $headers;
 	}
 


### PR DESCRIPTION
wordpress.com等、[Batcache](https://github.com/Automattic/batcache) が有効になっている環境において、フォームの入力内容がキャッシュされ第三者が閲覧可能になることを確認しました。

再現環境：https://ylikr.wpcomstaging.com/contact-2/
再現手順：
1. 上記ページにアクセスする
1. nameに「あ」を入力し、emailを空欄のまま CONFIRM ボタンを押す
1. 別ブラウザで上記ページにアクセスするとnameの内容とバリデーションエラーが表示される
補足：
- Batcacheの設定によると120秒以内に同一ページに2回アクセスした際に300秒間キャッシュされる
  - https://github.com/Automattic/batcache/blob/master/advanced-cache.php#L43-L48
- cookieのnameが「wp」「wordpress」「comment_author」のいずれかから始まるものが含まれているとキャッシュされないので、再現のためにはそれらを削除しておく必要がある
  - https://github.com/Automattic/batcache/blob/master/advanced-cache.php#L384-L392
- キャッシュされている場合にはHTTPレスポンスヘッダーに「x-nananana: Batcache-Hit」が含まれる

対策としてCache-Controlに「max-age=0」を追加しました。
Batcacheの実装を見る限り、no-cache等は無視されますが、max-ageからキャッシュの有効期限を設定するようです。
https://github.com/Automattic/batcache/blob/master/advanced-cache.php#L236-L238
上記ページでこの修正を反映したところキャッシュが起きなくなることを確認しました。